### PR TITLE
Finished Exercise 1

### DIFF
--- a/iOSBookChapter6/Base.lproj/Main.storyboard
+++ b/iOSBookChapter6/Base.lproj/Main.storyboard
@@ -90,7 +90,6 @@
                                         </state>
                                     </button>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="300" id="4rn-2q-Zdy"/>
                                 </constraints>
@@ -111,7 +110,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="447" y="337"/>
+            <point key="canvasLocation" x="244" y="102"/>
         </scene>
     </scenes>
     <resources>
@@ -120,9 +119,6 @@
         <image name="user3" width="100" height="139"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray2Color">
-            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/iOSBookChapter6/Base.lproj/Main.storyboard
+++ b/iOSBookChapter6/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina5_5" orientation="portrait" appearance="light"/>
+    <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,23 +13,26 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="iOSBookChapter6" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="SVy-cD-PHT">
-                                <rect key="frame" x="10" y="50" width="394" height="266.66666666666669"/>
+                                <rect key="frame" x="10" y="50" width="1004" height="569.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="A8g-lj-AGZ">
-                                        <rect key="frame" x="0.0" y="0.0" width="394" height="68.333333333333329"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1004" height="98.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Instant Developer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="ZDl-uM-wsC">
-                                                <rect key="frame" x="42.666666666666657" y="0.0" width="308.66666666666674" height="48"/>
+                                                <rect key="frame" x="255" y="0.0" width="494.5" height="78"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="40"/>
                                                 <color key="textColor" systemColor="systemRedColor"/>
                                                 <nil key="highlightedColor"/>
+                                                <variation key="heightClass=regular-widthClass=regular">
+                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="65"/>
+                                                </variation>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Get help from experts in 15 minutes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qJL-Mz-YM8">
-                                                <rect key="frame" x="62" y="48" width="270.33333333333331" height="20.333333333333329"/>
+                                                <rect key="frame" x="367" y="78" width="270.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -37,22 +40,22 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aJe-mP-GUJ">
-                                        <rect key="frame" x="0.0" y="78.333333333333343" width="394" height="158"/>
+                                        <rect key="frame" x="0.0" y="108.5" width="1004" height="430.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user1" translatesAutoresizingMaskIntoConstraints="NO" id="xSc-3K-z4f">
-                                                <rect key="frame" x="0.0" y="0.0" width="118" height="158"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="321.5" height="430.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="xSc-3K-z4f" secondAttribute="height" multiplier="50:67" id="oue-yf-tJJ"/>
                                                 </constraints>
                                             </imageView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user2" translatesAutoresizingMaskIntoConstraints="NO" id="loQ-tU-zGd">
-                                                <rect key="frame" x="138" y="0.0" width="118" height="158"/>
+                                                <rect key="frame" x="341.5" y="0.0" width="321" height="430.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="loQ-tU-zGd" secondAttribute="height" multiplier="50:67" id="2DP-sm-JAn"/>
                                                 </constraints>
                                             </imageView>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user3" translatesAutoresizingMaskIntoConstraints="NO" id="qDB-ip-TrB">
-                                                <rect key="frame" x="276" y="0.0" width="118" height="158"/>
+                                                <rect key="frame" x="682.5" y="0.0" width="321.5" height="430.5"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="qDB-ip-TrB" secondAttribute="height" multiplier="50:67" id="Cz4-Cx-vdK"/>
                                                 </constraints>
@@ -60,7 +63,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Need help with coding problems? Register!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="2fG-bN-HfX">
-                                        <rect key="frame" x="0.0" y="246.33333333333334" width="394" height="20.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="549" width="1004" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -70,25 +73,26 @@
                                 <variation key="heightClass=compact" alignment="center"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Gqj-PM-T4X">
-                                <rect key="frame" x="107" y="646" width="200" height="70"/>
+                                <rect key="frame" x="362" y="1276" width="300" height="70"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9W3-19-LqI">
-                                        <rect key="frame" x="0.0" y="0.0" width="200" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="300" height="30"/>
                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                         <state key="normal" title="Sign up">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XhK-G3-jec">
-                                        <rect key="frame" x="0.0" y="40" width="200" height="30"/>
+                                        <rect key="frame" x="0.0" y="40" width="300" height="30"/>
                                         <color key="backgroundColor" systemColor="systemRedColor"/>
                                         <state key="normal" title="Login with Facebook">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
                                     </button>
                                 </subviews>
+                                <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="Fbn-nf-NAI"/>
+                                    <constraint firstAttribute="width" constant="300" id="4rn-2q-Zdy"/>
                                 </constraints>
                             </stackView>
                         </subviews>
@@ -107,7 +111,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="738" y="332"/>
+            <point key="canvasLocation" x="447" y="337"/>
         </scene>
     </scenes>
     <resources>
@@ -116,6 +120,9 @@
         <image name="user3" width="100" height="139"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
             <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Changed the width of the Sign up & Log in with Facebook buttons to 300 points for all devices
Increased the font size of Instant Developer label to 65 from 40, only for iPads (using Size Classes)

![Screenshot 2020-11-25 at 16 42 28](https://user-images.githubusercontent.com/38860865/100242655-bcae9280-2f3d-11eb-9d8e-6ea1f7fdc291.png)

